### PR TITLE
Update config

### DIFF
--- a/.tmux.conf.local.overrides
+++ b/.tmux.conf.local.overrides
@@ -132,6 +132,14 @@ set -g @resurrect-restore 'R'
 set -g @resurrect-save 'S'
 run-shell '~/.tmux/plugins/tmux-resurrect/resurrect.tmux'
 
+# neovim suggestion to enable truecolors, disabled because I prefer cterm
+# see: https://www.elliottchenstudio.com/blog/neovim-true-color
+# set-option -sa terminal-features ',tmux-256color:RGB'
+
+# both settings needed to override the default colors
+set -g default-terminal "xterm-256color"
+set-option -ga terminal-overrides ",xterm-256color:Tc"
+
 # EOF
 #
 # # exit the script if any statement returns a non-true return value
@@ -162,6 +170,7 @@ run-shell '~/.tmux/plugins/tmux-resurrect/resurrect.tmux'
 #   not_a_repo=$(git rev-parse --git-dir &> /dev/null || echo true)
 #   [ $not_a_repo ] && tmux display-message "not a git repository" && return
 #   [ $2 ] && opt='--cached'
+#   # Too difficult to read using `delta` because of the two columns
 #   tmux split-window -h \
 #     "git --no-pager diff $opt | diff-so-fancy | LESS='-RSX' less"
 # }

--- a/.tmux.conf.local.overrides
+++ b/.tmux.conf.local.overrides
@@ -102,11 +102,11 @@ bind -n M-d run "${get_functions} | sh -s _gitdiffwin #{pane_current_path} cache
 bind -n M-D run "${get_functions} | sh -s _gitdiffwin #{pane_current_path}"
 
 # edit tmux config
-bind e new-window -n "~/.tmux.conf" "cd ~/.tmux && \${EDITOR:-vim} ~/.tmux.conf* \
+bind e new-window -n "~/.tmux.conf" "cd ~/.tmux && \${EDITOR} ~/.tmux.conf* \
   && tmux source ~/.tmux.conf && tmux display '~/.tmux.conf sourced'"
 
 # edit zsh related config
-bind z new-window -n "~/.zprezto" "cd ~/.zprezto && \${EDITOR:-vim} \
+bind z new-window -n "~/.zprezto" "cd ~/.zprezto && ${EDITOR} \
   ~/.zprezto/{runcoms/{p10k.zsh,zshrc},complements/*(.)}"
 
 # don't leave vi copy-mode after copying the selection

--- a/.tmux.conf.local.overrides
+++ b/.tmux.conf.local.overrides
@@ -89,6 +89,10 @@ bind 0 select-layout d537,173x46,0,0[173x38,0,0,0,173x7,0,39,1]
 # rename the session (not the window)
 bind F2 command-prompt -p rename-session 'rename-session %%'
 
+# sync panes
+bind Y set-window-option synchronize-panes\; \
+  display-message "synchronize-panes #{?pane_synchronized,on,off}"
+
 # custom functions
 get_functions='cut -c3- ~/.tmux.conf.local.overrides'
 bind -n M-u run "${get_functions} | sh -s _fzfurlview #{pane_id}"   # open URLs

--- a/.tmux.conf.local.overrides
+++ b/.tmux.conf.local.overrides
@@ -54,6 +54,7 @@ bind | split-window -h                                    # split current window
 bind -n M-k next-window                                   # select next window
 bind -n M-j previous-window                               # select previous window
 bind C-b last-window                                      # return to last active window
+bind -n M-` last-window                                   # return to last active window
 
 bind BSpace send-keys C-q                                 # send C-q to disable Xon
 bind -n M-Enter resize-pane -Z                            # zoom pane

--- a/.tmux.conf.local.overrides
+++ b/.tmux.conf.local.overrides
@@ -69,8 +69,7 @@ bind O choose-window "join-pane -v -s "%%""               # attach window in hor
 bind N join-pane -t :!                                    # attach last used pane
 bind B break-pane                                         # detach pane into its own window
 
-bind u set status off                                     # hide the status bar
-bind U set status on                                      # show the status bar
+bind u set status                                         # toggle the status bar
 
 # select window with Alt+Number
 bind -n M-1 select-window -t 1


### PR DESCRIPTION
* Add bind to return to last active window

* Simplify bind to toggle status bar

* Add bind to synchronize panes

* Fix envvar fallback

After a tmux upgrade, having default values for envvars break on init.

* Update color settings to prefer cterm
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tmux keybindings (M-` last-window, unified status toggle, Y to sync panes), switches edit commands to use $EDITOR, and sets terminal/color overrides.
> 
> - **tmux config (`.tmux.conf.local.overrides`)**:
>   - **Keybindings**:
>     - Add `bind -n M-\`` for `last-window`.
>     - Replace separate `status` on/off binds with a single toggle: `bind u set status`.
>     - Add `bind Y` to toggle `synchronize-panes` with a status message.
>   - **Edit commands**:
>     - Use `${EDITOR}` in `bind e` and `bind z` commands (remove fallback default).
>   - **Terminal/colors**:
>     - Set `default-terminal` to `"xterm-256color"` and append `,xterm-256color:Tc` to `terminal-overrides`.
>     - Add commented guidance regarding truecolor and `delta` readability in git diff helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c794e1da48d0384927db6131bbb7c3dbe42b2d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->